### PR TITLE
Migrate to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "attrievent"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1"

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumIter, EnumString};
 
@@ -874,10 +874,9 @@ mod tests {
             RawEventAttrKind::Network(NetworkAttr::Content)
         );
 
-        assert!(RawEventAttrKind::from_kind_and_attr_name(
-            &RawEventKind::Conn,
-            INVALID_ATTR_FIELD_NAME
-        )
-        .is_err());
+        assert!(
+            RawEventAttrKind::from_kind_and_attr_name(&RawEventKind::Conn, INVALID_ATTR_FIELD_NAME)
+                .is_err()
+        );
     }
 }


### PR DESCRIPTION
Only formatting changes from cargo fmt occurred as a result of upgrading the Rust edition from 2021 to 2024.

Close: #14