### PR TITLE
Enforce Clippy lint against `unwrap`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check --config group_imports=StdExternalCrate
       - name: Clippy
-        run: cargo clippy --tests -- -D warnings -W clippy::pedantic
+        run: cargo clippy --tests -- -D warnings
       - name: markdownlint
         uses: articulate/actions-markdownlint@v1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 strum = "0.27"
 strum_macros = "0.27"
+
+[lints.clippy]
+pedantic = "warn"
+unwrap_used = "warn"


### PR DESCRIPTION
Closes #21 #24
- Set `unwrap_used = "warn"` in Cargo.toml
- Allowed `unwrap` in tests via `.clippy.toml`
- Added `pedantic = "warn"` for additional linting coverage